### PR TITLE
Ignore .babelrc files for babel-loader

### DIFF
--- a/kaba/shelf/js/JsDirectoryTask.js
+++ b/kaba/shelf/js/JsDirectoryTask.js
@@ -119,6 +119,7 @@ module.exports = class JsDirectoryTask
                                 test: /\.jsx?$/,
                                 loader: "babel-loader?cacheDirectory",
                                 options: {
+                                    babelrc: false,
                                     presets: [
                                         require("kaba-babel-preset"),
                                     ],


### PR DESCRIPTION
Twitter-Thread: https://twitter.com/cH40zLord/status/894930799857995776

This fixes an issue that first occurred in Preact v8.2.0/v8.2.1 where WebPack tried to compile `preact.esm.js` and failed. It claimed some dependencies were missing that were present for the app-specific JavaScripts though.