### PR TITLE
JavaScript file types and their extensions are ridiculous

### DIFF
--- a/lib/Kaba.js
+++ b/lib/Kaba.js
@@ -572,7 +572,7 @@ class Kaba
             if (!this.typescript.compileJs)
             {
                 config.module.rules.unshift({
-                    test: /\.jsx?$/,
+                    test: /\.m?jsx?$/,
                     use: [babelLoader],
                 });
             }
@@ -581,7 +581,7 @@ class Kaba
         {
             // add Babel
             config.module.rules.unshift({
-                test: /\.jsx?$/,
+                test: /\.m?jsx?$/,
                 use: [babelLoader],
             });
         }
@@ -611,7 +611,7 @@ class Kaba
         {
             config.module.rules.push({
                 enforce: "pre",
-                test: /\.jsx?$/,
+                test: /\.m?jsx?$/,
                 exclude: /node_modules|vendor/,
                 loader: "eslint-loader",
                 options: {


### PR DESCRIPTION
We also need to support `.mjs` files (are `.mjsx` a thing?)

Yay for JavaScript and their totally random file extensions.