### PR TITLE
Automatically provide an import for `h()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 *   Changed the webpack include order, to avoid false-positive TypeScript errors.
 *   Activated the `no-prototype-builtins` ESLint rule.
- 
+*   Automatically add the import for the `h()` function from preact for all modules.
+
 
 8.0
 ===

--- a/lib/Kaba.js
+++ b/lib/Kaba.js
@@ -3,6 +3,7 @@ const kabaBabelPreset = require("kaba-babel-preset");
 const {blue, red, yellow} = require("kleur");
 const fs = require("fs-extra");
 const path = require("path");
+const {ProvidePlugin} = require("webpack");
 const TerserPlugin = require('terser-webpack-plugin');
 const typeScriptErrorFormatter = require("@becklyn/typescript-error-formatter");
 
@@ -97,6 +98,9 @@ class Kaba
          */
         this.plugins = [
             new CleanWebpackPlugin(),
+            new ProvidePlugin({
+                h: ["preact", "h"],
+            }),
         ];
 
         /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | yes<!-- improves an existing feature, not adding a new one --> 
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->
Making the life a bit easier by reducing the number of manual imports. And this one should be completely transparent to the user.