### PR TITLE
Use better default public path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 *   Always build a legacy and a modern JS build.
 *   Added `verbose` to the CLI config.
 *   Improved error handling of `node-sass` loading errors.
+*   Use better default `publicPath` to match the default structure of the BecklynAssetsBundle.
 
 
 8.1.0

--- a/src/Kaba.ts
+++ b/src/Kaba.ts
@@ -42,7 +42,7 @@ export class Kaba
         css: "",
         js: "",
     };
-    private publicPath: string = "/assets/";
+    private publicPath: string = "/assets/app/js/";
     private externals: Externals = {};
     private moduleConcatenationEnabled: boolean = false;
     private plugins: webpack.Plugin[] = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | yes<!-- improves an existing feature, not adding a new one --> 
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->
This path matches the directory structure of a Becklyn AssetsBundle project.

Not a bugfix, because the previous path basically didn't work for any project.