### PR TITLE
Go back to include list + bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 *   (improvement) The code is now always compiled per entry file
 *   (improvement) Build TypeScript for the `esnext` module system, that (amongst other things) allows to use `import()`.
 *   (bug) Compile every entry into a separate directory, to avoid issues with the clean plugin.
-*   (bc) Now you can defined which packages in `node_modules` should NOT be transformed. Use `.ignoreNpmPackages(...)`.
+*   (bc) Not all npm packages are automatically transpiled anymore. You need to define which packages from `node_modules` to transpile via Babel by using `.compileNpmPackages(...)`.
 *   (feature) Even if not recommended (use SCSS!), we now support compiling CSS via webpack (not as entry point though). The CSS will be injected into the head dynamically.
 
 

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
         "test": "npm run-script build && ava"
     },
     "optionalDependencies": {
-        "kaba-scss": "^3.3.2",
+        "kaba-scss": "^3.3.5",
         "webpack-bundle-analyzer": "^3.6.0"
     },
     "dependencies": {
-        "@babel/core": "^7.8.3",
+        "@babel/core": "^7.8.4",
         "@becklyn/typescript-error-formatter": "^1.0.4",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
@@ -32,11 +32,11 @@
         "duplicate-package-checker-webpack-plugin": "^3.0.0",
         "eslint": "^6.8.0",
         "eslint-loader": "^3.0.3",
-        "eslint-plugin-jsdoc": "^20.3.0",
-        "eslint-plugin-react": "^7.17.0",
+        "eslint-plugin-jsdoc": "^21.0.0",
+        "eslint-plugin-react": "^7.18.3",
         "eslint-plugin-react-hooks": "^2.3.0",
         "fs-extra": "^8.1.0",
-        "kaba-babel-preset": "^4.1.1",
+        "kaba-babel-preset": "^4.1.2",
         "kleur": "^3.0.3",
         "postcss-loader": "^3.0.0",
         "pretty-hrtime": "^1.0.3",
@@ -44,15 +44,15 @@
         "raw-loader": "^4.0.0",
         "sade": "^1.7.0",
         "style-loader": "^1.1.3",
-        "terser-webpack-plugin": "^2.3.2",
+        "terser-webpack-plugin": "^2.3.4",
         "ts-loader": "^6.2.1",
-        "typescript": "^3.7.4",
+        "typescript": "^3.7.5",
         "webpack": "^4.41.5"
     },
     "devDependencies": {
         "@types/terser-webpack-plugin": "^2.2.0",
         "ava": "^2.4.0",
-        "kaba-scss": "^3.3.2",
+        "kaba-scss": "^3.3.5",
         "webpack-bundle-analyzer": "^3.6.0"
     },
     "engines": {

--- a/src/Kaba.ts
+++ b/src/Kaba.ts
@@ -401,7 +401,6 @@ export class Kaba
                     "node_modules",
                 ],
 
-                // TS is potentially added below
                 extensions: [
                     ".mjs",
                     ".mjsx",

--- a/src/Kaba.ts
+++ b/src/Kaba.ts
@@ -12,7 +12,7 @@ const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const PACKAGE_MATCHER = /\/node_modules\/(?<package>(?:@[^@\/]+\/)?[^@\/]+)\//;
-type IgnoredNpmPackagesMapping = Array<RegExp|string>;
+type CompiledNpmPackagesMapping = Array<RegExp|string>;
 const ignoredPackagesCache: {[k: string]: boolean} = {};
 interface PostCssLoaderOptions {[key: string]: any}
 
@@ -36,7 +36,7 @@ interface Externals
 /**
  * Determines whether a file should processed by the asset pipeline.
  */
-function isAllowedPath (path: string, ignoredPackages: IgnoredNpmPackagesMapping) : boolean
+function isAllowedPath (path: string, compiledPackages: CompiledNpmPackagesMapping) : boolean
 {
     const match = PACKAGE_MATCHER.exec(path);
 
@@ -53,25 +53,25 @@ function isAllowedPath (path: string, ignoredPackages: IgnoredNpmPackagesMapping
         return ignoredPackagesCache[packageNameToCompile];
     }
 
-    const length = ignoredPackages.length;
+    const length = compiledPackages.length;
     for (let i = 0; i < length; ++i)
     {
-        const ignoredPackage = ignoredPackages[i];
+        const compiledPackage = compiledPackages[i];
 
-        if (typeof ignoredPackage == "string")
+        if (typeof compiledPackage == "string")
         {
-            if (ignoredPackage === packageNameToCompile)
+            if (compiledPackage === packageNameToCompile)
             {
-                return ignoredPackagesCache[packageNameToCompile] = false;
+                return ignoredPackagesCache[packageNameToCompile] = true;
             }
         }
-        else if (ignoredPackage.test(packageNameToCompile))
+        else if (compiledPackage.test(packageNameToCompile))
         {
-            return ignoredPackagesCache[packageNameToCompile] = false;
+            return ignoredPackagesCache[packageNameToCompile] = true;
         }
     }
 
-    return ignoredPackagesCache[packageNameToCompile] = true;
+    return ignoredPackagesCache[packageNameToCompile] = false;
 }
 
 /**
@@ -96,11 +96,10 @@ export class Kaba
     private hashFileNames: boolean = true;
     private buildModern: boolean = true;
     private nodeSettings: webpack.Node|false = false;
-    private ignoredNpmPackages: IgnoredNpmPackagesMapping = [
-        /^@babel/,
-        /^babel-/,
-        /^core-js(-|$)/,
-        /^regenerator-/,
+    private compiledNpmPackages: CompiledNpmPackagesMapping = [
+        /^@becklyn/,
+        /^@mayd/,
+        /^mojave/,
     ];
     private postCssLoaderOptions: PostCssLoaderOptions = {};
 
@@ -129,11 +128,11 @@ export class Kaba
 
 
     /**
-     * Defines which npm packages are NOT compiled with babel
+     * Defines which npm packages are compiled with babel.
      */
-    public ignoreNpmPackages (modules: Array<string|RegExp>): this
+    public compileNpmPackages (modules: Array<string|RegExp>): this
     {
-        this.ignoredNpmPackages = this.ignoredNpmPackages.concat(modules);
+        this.compiledNpmPackages = this.compiledNpmPackages.concat(modules);
         return this;
     }
 
@@ -438,14 +437,14 @@ export class Kaba
                                 },
                             },
                         ],
-                        include: (path: string) => isAllowedPath(path, this.ignoredNpmPackages),
+                        include: (path: string) => isAllowedPath(path, this.compiledNpmPackages),
                     },
 
                     // Babel
                     {
                         test: /\.m?jsx?$/,
                         use: [babelLoader],
-                        include: (path: string) => isAllowedPath(path, this.ignoredNpmPackages),
+                        include: (path: string) => isAllowedPath(path, this.compiledNpmPackages),
                     },
 
                     // content files


### PR DESCRIPTION
Using an exclude list is a dead-end: there are way too many packages to exclude.
We basically only need to include our own...