### PR TITLE
Ignore TYPO3 typoscript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 *   (bug) Compile every entry into a separate directory, to avoid issues with the clean plugin.
 *   (bc) Not all npm packages are automatically transpiled anymore. You need to define which packages from `node_modules` to transpile via Babel by using `.compileNpmPackages(...)`.
 *   (feature) Even if not recommended (use SCSS!), we now support compiling CSS via webpack (not as entry point though). The CSS will be injected into the head dynamically.
-*   (improvement) TYPO3 typoscript files will be ignored.
+*   (improvement) TypeScript will now ignore TYPO3 (`*typo3*`) directories, to prevent issues due to file extension conflicts of TYPO3's typoscript `.ts` and TypeScript's `.ts`.
 
 
 8.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 *   (bug) Compile every entry into a separate directory, to avoid issues with the clean plugin.
 *   (bc) Not all npm packages are automatically transpiled anymore. You need to define which packages from `node_modules` to transpile via Babel by using `.compileNpmPackages(...)`.
 *   (feature) Even if not recommended (use SCSS!), we now support compiling CSS via webpack (not as entry point though). The CSS will be injected into the head dynamically.
+*   (improvement) TYPO3 typoscript files will be ignored.
 
 
 8.1.0

--- a/configs/tsconfig.legacy.json
+++ b/configs/tsconfig.legacy.json
@@ -21,6 +21,7 @@
     },
     "exclude": [
         "../node_modules",
-        "vendor"
+        "vendor",
+        "*typo3*"
     ]
 }

--- a/configs/tsconfig.modern.json
+++ b/configs/tsconfig.modern.json
@@ -22,6 +22,7 @@
     },
     "exclude": [
         "../node_modules",
-        "vendor"
+        "vendor",
+        "*typo3*"
     ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                                |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->

TYPO3 got some files that have the same suffix like typescript and they will be parsed as well. We just ignore them from now on.
