### PR TITLE
Add aliases to webpack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+9.1.0
+=====
+
+*   (improvement) Added `setWebpackConfigAliases` method to define aliases in the webpack build config.
+
+
 9.0.0
 =====
 

--- a/src/Kaba.ts
+++ b/src/Kaba.ts
@@ -103,6 +103,7 @@ export class Kaba
         /^auslese/,
     ];
     private postCssLoaderOptions: PostCssLoaderOptions = {};
+    private webpackAliases: Record<string, string> = {};
 
 
     /**
@@ -291,6 +292,16 @@ export class Kaba
 
 
     /**
+     * Sets the module aliases for webpack
+     */
+    public setWebpackConfigAliases (aliases: Record<string, string>): this
+    {
+        this.webpackAliases = aliases;
+        return this;
+    }
+
+
+    /**
      * Returns the kaba config
      *
      * @internal
@@ -410,6 +421,8 @@ export class Kaba
                     ".tsx",
                     ".json",
                 ],
+
+                alias: this.webpackAliases,
             },
 
             // output


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes<!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

When using `preact` you need to add a alias for `react` if you want to use packages that need a peer dependency of `react`: https://github.com/preactjs/preact-compat#usage-with-webpack (for `preact X` the alias looks different, but you still need one).
